### PR TITLE
Remove compilation warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -12,8 +12,8 @@ defmodule SecureCompare.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       description: "A simple constant-time comparison algorithm for Elixir",
-      package: package,
-      deps: deps
+      package: package(),
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
When running with Elixir 1.4 we get compilation errors because methods without arguments should still use parentheses.

```elixir
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:15

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:16
```

This PR adds the parentheses where they are missing to avoid the warnings.